### PR TITLE
fix: enable ts strict mode, prevent error when no plugins are installed

### DIFF
--- a/apps/yal/src/utils/third-party-plugins.ts
+++ b/apps/yal/src/utils/third-party-plugins.ts
@@ -33,7 +33,7 @@ async function getPluginsAndWaitForServer() {
     })
     .map((x) => x.name);
 
-  if (pluginNames.length === 0) return;
+  if (pluginNames.length === 0) return [];
   let serverConnected = false;
   // Wait for the server to spin up....
   while (!serverConnected) {

--- a/apps/yal/tsconfig.json
+++ b/apps/yal/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": true,
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "node",
@@ -11,8 +12,6 @@
     "noEmit": true,
     "isolatedModules": true,
     "baseUrl": "./src",
-    "lib": [
-      "es2020", "esnext", "dom"
-    ],
+    "lib": ["es2020", "esnext", "dom"]
   }
 }


### PR DESCRIPTION
I think it would be a good idea to use strict mode to ensure code quality and prevent bugs (such as in `third-party-plugins.ts`) going forward. :)

This change will make some existing type errors appear in the codebase though.